### PR TITLE
Add migrations to deployment image

### DIFF
--- a/docker-compose.deploy.yml
+++ b/docker-compose.deploy.yml
@@ -1,9 +1,7 @@
 version: "3"
 services:
   db: 
-    build:
-      context: dynamic
-      dockerfile: docker/Dockerfile.postgres
+    image: postgres:12.3
     ports:
       - "5432:5432"
     environment:

--- a/dynamic/docker/Dockerfile.deploy
+++ b/dynamic/docker/Dockerfile.deploy
@@ -8,9 +8,19 @@ RUN go mod download
 COPY . .
 RUN CGO_ENABLED=0 go build -o server ./cmd/server
 
+
+FROM alpine:3.13.5 AS migration-fetcher
+
+RUN apk add --no-cache curl
+RUN curl -L https://github.com/golang-migrate/migrate/releases/download/v4.11.0/migrate.linux-amd64.tar.gz | tar xvz
+
+
 FROM alpine:3.13.5 AS runner
 
 RUN apk add --no-cache tzdata
 COPY --from=builder /app/server .
+COPY --from=migration-fetcher /migrate.linux-amd64 .
 COPY docker/startup.deploy.sh .
+COPY storage/postgres/migrations /migrations
+
 CMD ./startup.deploy.sh

--- a/dynamic/docker/startup.deploy.sh
+++ b/dynamic/docker/startup.deploy.sh
@@ -20,4 +20,7 @@ until nc -z $(echo $DSS_POSTGRESURL | sed "s%^.*@\(.*\):\(.*\)\/.*$%\1 \2%"); do
 	sleep 1; \
 done; \
 
+
+/migrate.linux-amd64 -path=/migrations -database $DSS_POSTGRESURL up
+
 ./server


### PR DESCRIPTION
This isn't the best way to do it, but it'll work as long as we don't
have multiple worker images.